### PR TITLE
fix: correct websocket service name and pending request log

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import { IntentsService } from './services/intents.service';
 import { NearService } from './services/near.service';
 import { QuoterService } from './services/quoter.service';
 import { HttpService } from './services/http.service';
-import { WebsocketConnectionService } from './services/websocket-connection.servce';
+import { WebsocketConnectionService } from './services/websocket-connection.service';
 
 export async function app() {
   const cacheService = new CacheService();

--- a/src/services/websocket-connection.service.ts
+++ b/src/services/websocket-connection.service.ts
@@ -47,7 +47,7 @@ export class WebsocketConnectionService {
   }
 
   private async sendRequestToRelay<TResult = unknown>(method: RelayMethod, params: unknown[], logger: LoggerService) {
-    logger.debug(`Number of pending requests before send: ${Object.keys(this.pendingRequests).length}`);
+    logger.debug(`Number of pending requests before send: ${this.pendingRequests.size}`);
     const request: IJsonrpcRelayRequest = {
       id: this.requestCounter++,
       jsonrpc: '2.0',


### PR DESCRIPTION
## Summary
- rename misnamed websocket-connection service file and update imports
- log pending websocket requests reliably using Map.size

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a5a300d6b8832ca8523e9b12ac5425