### PR TITLE
Added GH runner to build and store image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,75 @@
+name: Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag'
+        required: true
+  release:
+    types: [created]
+  push:
+    branches: [ main ]  # Only build on pushes to main branches
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  VERSION: ${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name || 'latest' }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if VERSION follows the x.x.x format
+        run: |
+          if [[ "${{ env.VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "LATEST_TAG_ENABLED=true" >> $GITHUB_ENV
+          else
+            echo "LATEST_TAG_ENABLED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=semver,pattern={{version}},value=${{ env.VERSION }}
+            type=raw,value=latest,enable=${{ env.LATEST_TAG_ENABLED == 'true' }}
+            type=raw,value=testnet
+          flavor: |
+            latest=false
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ env.VERSION }}


### PR DESCRIPTION
Runner for building image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Official Docker images are now published to GHCR for linux/amd64 and linux/arm64.
  - Images are tagged with semantic versions, branch, commit SHA, and “latest” for x.y.z releases.

- Chores
  - Added an automated workflow to build and push Docker images on release creation, pushes to main, and manual runs.
  - Improved build reliability and speed with metadata-driven tagging and build caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->