### PR TITLE
docs: add known nonce limitation to AMM solver README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ Development mode (with automatic reload):
 npm run dev
 ```
 
+### Known Limitations
+
+The current AMM solver reuses the same nonce for transaction submissions. This was done as a simple way to avoid slippage in the AMM pricing logic (by ensuring deterministic ordering).
+
+**Impact**: Throughput is limited to roughly **1 swap every 1-2 seconds** (waiting for each transaction to be included before the next nonce becomes valid).
+
+This is intentional for the example to keep the code minimal and easy to understand. Production-grade solvers should:
+
+- Track pending nonces properly
+- Use unique nonces + sequencing logic
+- Or batch multiple intents where possible
+
+Contributions improving nonce handling (while keeping the example simple) are very welcome!
+
 TEE mode:
 
 You have multiple ways to run the solver inside TEE:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ Development mode (with automatic reload):
 npm run dev
 ```
 
-### Known Limitations
+TEE mode:
+
+You have multiple ways to run the solver inside TEE:
+
+1. use the [TEE solver server](https://github.com/Near-One/tee-solver/tree/main/server)
+2. follow the [Phala Cloud](https://docs.phala.com/phala-cloud/cvm/overview) docs
+
+## Known Limitations
 
 The current AMM solver reuses the same nonce for transaction submissions. This was done as a simple way to avoid slippage in the AMM pricing logic (by ensuring deterministic ordering).
 
@@ -118,14 +125,7 @@ The current AMM solver reuses the same nonce for transaction submissions. This w
 This is intentional for the example to keep the code minimal and easy to understand. Production-grade solvers should:
 
 - Track pending nonces properly
-- Use unique nonces + sequencing logic
+- Use unique nonces and sequencing logic
 - Or batch multiple intents where possible
 
 Contributions improving nonce handling (while keeping the example simple) are very welcome!
-
-TEE mode:
-
-You have multiple ways to run the solver inside TEE:
-
-1. use the [TEE solver server](https://github.com/Near-One/tee-solver/tree/main/server)
-2. follow the [Phala Cloud](https://docs.phala.com/phala-cloud/cvm/overview) docs


### PR DESCRIPTION
This PR adds a "Known Limitations" section to the README to honestly document the current nonce handling behavior in the example AMM solver.

The same nonce is reused for transaction submissions (a simplification to avoid slippage in the example's pricing logic). As a result, the solver is limited to roughly **1 swap every 1–2 seconds**, since each transaction must be finalized before the next nonce becomes usable.

This change follows the community discussion in the NEAR Doc Telegram group (@neardocscg ), where @guilledevrel explicitly invited PRs:

> "I agree, please open a PR on the AMM solver example or docs, if you ping me and I can review it 🙏"

The added text clearly states:
- Why the limitation exists (intentional simplicity for the example)
- The observed impact (1 swap / 1–2s throughput)
- That production-grade solvers should implement proper nonce tracking, sequencing, or batching
- An open invitation for contributions to improve it

No code changes are made — this is purely documentation to set correct expectations for anyone following the quickstart or building from the example.

cc @gagdiez for review 🙏