### PR TITLE
feat: add relay token filters

### DIFF
--- a/src/services/websocket-connection.service.ts
+++ b/src/services/websocket-connection.service.ts
@@ -222,7 +222,9 @@ export class WebsocketConnectionService {
   }
 
   private async subscribe(eventKind: RelayEventKind, logger: LoggerService) {
-    const subscriptionId = await this.sendRequestToRelay(RelayMethod.SUBSCRIBE, [eventKind], logger);
+    const params =
+      eventKind === RelayEventKind.QUOTE ? [eventKind, { tokens_in: tokens, tokens_out: tokens }] : [eventKind];
+    const subscriptionId = await this.sendRequestToRelay(RelayMethod.SUBSCRIBE, params, logger);
     logger.debug(`Got subscriptionId for '${eventKind}': ${subscriptionId}`);
     if (typeof subscriptionId !== 'string') {
       throw new Error(`Unexpected subscriptionId type`);


### PR DESCRIPTION
Adds tokens_in and tokens_out filters to the relay quote subscription using the two configured AMM tokens. This limits delivered quote requests to pairs the sample solver can handle while leaving the quote_status subscription unchanged.